### PR TITLE
to let solutions to the problems more obvious in the readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -29,9 +29,16 @@ Libraries have been installed in:
 
 Then you can build the library with `COIN_LIB_DIR=<SOME_PATH> cargo build`.
 
-Something went wrong?
-- check your version of [bash] to run the script
-- check that you have the proper [build dependencies]
+**Something went wrong?**
+- check your version of [bash] to run the script. You may need to update your bash on mac with:
+  ```sh
+  brew install bash
+  ```
+- check that you have the proper [build dependencies]. You may need to do:
+  ```sh
+  brew install gcc wget svn git
+  ```
+  to install dependencies, such as Fortran compiler which is required to build this lib.
 
 ## Testing
 


### PR DESCRIPTION
The instructions in `README` actually have all the info we need to fix problems that we may encounter during the build process but they are not obvious.

 This PR is just to make it more obvious to save some time digging. 